### PR TITLE
fix(seed): lowerFirst model name to get method name, not camelCase

### DIFF
--- a/src/static/seed.ts
+++ b/src/static/seed.ts
@@ -957,13 +957,13 @@ export function getSeed<
           {},
         )
 
-      const methodName = _.camelCase(currentTask.mapping.model)
+      const methodName = _.lowerFirst(currentTask.mapping.model)
       /**
        * Make sure that client packs everyting.
        */
       if (!client[methodName]) {
         throw new Error(
-          `Client is missing method for ${currentTask.model.name}`,
+          `Client is missing method for ${currentTask.model.name} (methodName = ${methodName}, mappingModel = ${currentTask.mapping.model})`,
         )
       }
 


### PR DESCRIPTION
seed was using the wrong assumption that the method names of the client are created by camelCasing the model name. In reality they are created by lowercasing the first letter.

closes #16